### PR TITLE
Enhanced Type Conversion for Rojo Project JSON Serialization

### DIFF
--- a/src/external-code/GenerateStructure/GenerateStructure.lua
+++ b/src/external-code/GenerateStructure/GenerateStructure.lua
@@ -26,12 +26,9 @@ return function (object : Instance)
         return nil
     end
 
-    local structure = propertyHandlers[object.ClassName](nil, object)
-    addObjectTags(structure, object)
-
-    structure["tree"] = {
-        ["$className"] = "DataModel"
-    }
+    local structure = {["name"] = object.Name}
+    structure["tree"] = propertyHandlers[object.ClassName](nil, object)
+    addObjectTags(structure["tree"], object)
 
     for index : number, child: Instance in pairs(object:GetChildren()) do
         structure["tree"][string.format("%d-%s", index, child.Name)] = generateChildStruct(child)

--- a/src/external-code/Serialization/Dependencies/Conversions/BrickColor.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/BrickColor.lua
@@ -1,0 +1,3 @@
+return function (value : BrickColorValue)
+   return string.format("{\"BrickColor\" : %d}", value.Number)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/CFrame.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/CFrame.lua
@@ -1,0 +1,13 @@
+local function vectorToTable(vector : Vector3)
+    return {vector.X,vector.Y,vector.Z}
+end
+
+
+return function (cframe : CFrameValue)
+    local position = table.concat(vectorToTable(cframe.Position),',')
+    local XOrientation = table.concat(vectorToTable(cframe.Rotation.XVector),',')
+    local YOrientation = table.concat(vectorToTable(cframe.Rotation.YVector),',')
+    local ZOrientation = table.concat(vectorToTable(cframe.Rotation.ZVector),',')
+
+    return string.format('{"CFrame" : {"position" : [%s], "orientation" : [[%s],[%s],[%s]]}}', position, XOrientation, YOrientation, ZOrientation)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Color3.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Color3.lua
@@ -1,0 +1,4 @@
+return function (value : Color3)
+    local colors = table.concat({value.R, value.G, value.B},',')
+    return string.format('{"Color3" : [%s]}', colors)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Color3uint8.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Color3uint8.lua
@@ -1,0 +1,4 @@
+return function (value : Color3)
+    local colors = table.concat({value.R, value.G, value.B},',')
+    return string.format('{"Color3" : [%s]}', colors)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/ColorSequence.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/ColorSequence.lua
@@ -1,0 +1,14 @@
+return function (value : ColorSequence)
+    local keypoints = value.Keypoints
+    local keypointString = ""
+    for i = 1, #keypoints do
+        local colorTbl = {keypoints[i].Value.R,keypoints[i].Value.G,keypoints[i].Value.B}
+        keypointString = keypointString .. string.format('{"time" : %f, "color" : [%s]}',keypoints[i].Time, table.concat(colorTbl,','))
+
+        if i ~= #keypoints then
+            keypointString = keypointString .. ', '
+        end
+    end
+
+    return string.format('{"ColorSequence" : { "keypoints" : [%s]}}', keypointString)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/EnumItem.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/EnumItem.lua
@@ -1,0 +1,3 @@
+return function (value : EnumItem)
+   return string.format('{"Enum" : %d}', value.Value) 
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/NumberSequence.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/NumberSequence.lua
@@ -1,0 +1,13 @@
+return function (value : NumberSequence)
+    local keypoints = value.Keypoints
+    local keypointString = ""
+    for i = 1, #keypoints do
+        keypointString = keypointString .. string.format('{"time" : %f, "value" : %f, "envelope" : %f}',keypoints[i].Time, keypoints[i].Value, keypoints[i].Envelope)
+
+        if i ~= #keypoints then
+            keypointString = keypointString .. ', '
+        end
+    end
+
+    return string.format('{"NumberSequence" : { "keypoints" : [%s] }}', keypointString)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/UDim.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/UDim.lua
@@ -1,0 +1,4 @@
+return function (value: UDim)
+    local tabValue = {value.Scale, value.Offset}
+    return string.format('{"UDim" : [%s]}', table.concat(tabValue,','))
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/UDim2.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/UDim2.lua
@@ -1,0 +1,4 @@
+return function (value: UDim2)
+    local tabValue = {{value.X.Scale, value.X.Offset}, {value.Y.Scale, value.Y.Offset}}
+    return string.format('{"UDim2" : [[%s], [%s]]}', table.concat(tabValue[1],','), table.concat(tabValue[2],','))
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Vector2.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Vector2.lua
@@ -1,0 +1,4 @@
+return function (value : Vector2)
+    local tablePos = {value.X, value.Y}
+    return string.format('{"Vector2" : [%s]}', table.concat(tablePos,',')) 
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Vector2int16.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Vector2int16.lua
@@ -1,0 +1,4 @@
+return function (value : Vector2int16)
+    local tablePos = {value.X, value.Y}
+    return string.format('{"Vector2int16" : [%s]}', table.concat(tablePos,',')) 
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Vector3.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Vector3.lua
@@ -1,0 +1,4 @@
+return function (value : Vector3)
+    local tablePos = {value.X, value.Y, value.Z}
+    return string.format('{"Vector3" : [%s]}', table.concat(tablePos,',')) 
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/Vector3int16.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/Vector3int16.lua
@@ -1,0 +1,4 @@
+return function (value : Vector3int16)
+    local tablePos = {value.X, value.Y, value.Z}
+    return string.format('{"Vector3int16" : [%s]}', table.concat(tablePos,',')) 
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/boolean.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/boolean.lua
@@ -1,0 +1,3 @@
+return function(value)
+    return string.format("{\"Bool\": %s}", value and "true" or "false")
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/number.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/number.lua
@@ -1,0 +1,3 @@
+return function (value : number)
+    return tostring(value)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/string.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/string.lua
@@ -1,0 +1,3 @@
+return function (value : string)
+    return string.format('"%s"', value)
+end

--- a/src/external-code/Serialization/Dependencies/Conversions/table.lua
+++ b/src/external-code/Serialization/Dependencies/Conversions/table.lua
@@ -1,0 +1,3 @@
+return function (value : table)
+    return string.format("[%s]", table.concat(value, ','))
+end

--- a/src/external-code/Serialization/Dependencies/ConvertToRojoString.lua
+++ b/src/external-code/Serialization/Dependencies/ConvertToRojoString.lua
@@ -1,0 +1,14 @@
+local Conversions = {}
+
+for _, module : ModuleScript in pairs(script.Parent:WaitForChild("Conversions"):GetChildren()) do
+    Conversions[module.Name] = require(module)
+end
+
+return function (value)
+    if Conversions[typeof(value)] then
+       return Conversions[typeof(value)](value) 
+    else
+        warn(string.format("No valid conversion for [%s]... Feel free to make your own and or contribute to the repository :)", typeof(value)))
+        return "\"NOT IMPLEMENTED\""
+    end    
+end

--- a/src/external-code/Serialization/SerializeTable.lua
+++ b/src/external-code/Serialization/SerializeTable.lua
@@ -1,0 +1,44 @@
+local toRojoString = require(script:WaitForChild("Dependencies"):WaitForChild("ConvertToRojoString"))
+
+local function isDict(tableToCheck)
+    for _,_ in ipairs(tableToCheck) do
+        return false
+    end
+
+    for _,_ in pairs(tableToCheck) do
+        return true
+    end
+
+    return false
+end
+
+local function serialize(object : {any : any}, depth : number?)
+    depth = depth or 0
+    local indent = string.rep('\t', depth)
+    local str = "{\n"
+    local totalElements, processedElements = 0, 0
+
+    for _,_ in pairs(object) do totalElements += 1 end
+
+    for fieldName : string, value : any in pairs(object) do
+        processedElements += 1
+        str = str .. string.format("%s\t\"%s\" : ", indent, fieldName)
+
+        if type(value) == "table" and isDict(value) then
+            str = str .. serialize(value, depth + 1)
+        else
+            str = str .. toRojoString(value)
+        end 
+
+        if processedElements == totalElements then
+            str = str .. "\n"
+        else
+            str = str .. ",\n"
+        end
+    end
+    str = str .. indent .. "}"
+
+    return str
+end
+
+return serialize

--- a/src/main.client.lua
+++ b/src/main.client.lua
@@ -2,6 +2,7 @@ local Selection = game:GetService("Selection")
 local modules = script:WaitForChild("modules")
 
 local generateStructure = require(modules:WaitForChild("GenerateStructure"))
+local serialize = require(modules:WaitForChild("SerializeTable"))
 
 -- Create a new toolbar section titled "Instance To Rojo"
 local toolbar = plugin:CreateToolbar("Instance To Rojo")
@@ -16,7 +17,9 @@ local function onButtonClicked()
 	local selectedObjects = Selection:Get()
 	
 	for _, instance : Instance in pairs(selectedObjects) do
-		print(generateStructure(instance))
+		local propertyTable = generateStructure(instance)
+		print(propertyTable)
+		print(serialize(propertyTable))
 	end
 end
 

--- a/src/modules/SerializeTable.project.json
+++ b/src/modules/SerializeTable.project.json
@@ -1,0 +1,9 @@
+{
+    "name": "SerializeTable",
+    "tree": {
+        "$path" : "../external-code/Serialization/SerializeTable.lua",
+        "Dependencies" : {
+            "$path" : "../external-code/Serialization/Dependencies"
+        }
+    }
+}


### PR DESCRIPTION
This update introduces comprehensive type conversions for Rojo's JSON serialization. The new code efficiently translates complex Roblox types into their JSON-compatible counterparts, ensuring a seamless integration with Rojo projects.

Newly supported types include:
- BrickColor
- CFrame
- Color3 and related variants
- ColorSequence
- EnumItem
- NumberSequence
- UDim and UDim2
- Vector classes
- Primitive Lua types (boolean, number, string)
- Generic tables

These additions significantly bolster the flexibility of our serialization process, paving the way for more robust project configurations and easier data interchange. Contributions and reviews are welcome!
